### PR TITLE
Fix for Serbu shorty ufopedia entry not showing up

### DIFF
--- a/Rulesets/Ufopaedia.rul
+++ b/Rulesets/Ufopaedia.rul
@@ -836,6 +836,12 @@ ufopaedia:
     section: STR_SHOTGUNS
     listOrder: 607
 
+  - id: STR_SERBU
+    type_id: 4
+    text: STR_SERBU_UFOPAEDIA
+    section: STR_SHOTGUNS
+    listOrder: 608
+
 
   - id: STR_M60
     type_id: 4


### PR DESCRIPTION
The entry was missing in Ufopedia.rul despite the text for it existing later in the file.